### PR TITLE
docs: pilot metrics schema v1 + weekly scoreboard template

### DIFF
--- a/references/pilot-metrics-schema-v1.md
+++ b/references/pilot-metrics-schema-v1.md
@@ -9,12 +9,18 @@ Provide a canonical metrics schema and reporting cadence for pilot acquisition e
 
 ## canonical metric definitions
 - `outreaches_sent`: number of first-touch messages sent that day
-- `replies`: number of prospects who replied (any direction)
-- `positive_replies`: replies with clear interest/next-step intent
+- `replies`: count unique prospects who replied that day (multiple messages from the same prospect in one day count as 1)
+- `positive_replies`: unique replying prospects with clear interest/next-step intent
 - `discovery_calls_booked`: calls booked from outreach
 - `pilots_offered`: explicit pilot offer proposals sent
 - `pilots_closed_paid`: paid pilot agreements confirmed
 - `revenue_usd`: total USD value of paid pilots closed
+
+## derived KPI definitions (weekly scoreboard)
+- `reply_rate_pct` = `replies / outreaches_sent * 100`
+- `positive_reply_rate_pct` = `positive_replies / outreaches_sent * 100`
+- `call_book_rate_pct` = `discovery_calls_booked / outreaches_sent * 100`
+- `pilot_close_rate_pct` = `pilots_closed_paid / pilots_offered * 100` (0 if `pilots_offered` is 0)
 
 ## optional supporting metrics
 - `followups_sent`
@@ -41,20 +47,33 @@ Use only:
 - `converted_paid_pilot`
 
 ## reporting cadence
+### timezone + reporting cutover
+- Use UTC as the canonical timezone.
+- Daily reporting window is `00:00-23:59 UTC`.
+- Post one daily update after cutoff to avoid mixed-day counts.
+
 ### daily update
 Post in discussion #5 with:
-- date
+- date (UTC)
 - outreaches_sent
 - replies / positive_replies
 - discovery_calls_booked
 - pilots_offered / pilots_closed_paid
 - revenue_usd
 - top blocker (if any)
+- discussion_update_url
+- tracker_snapshot_ref
 
 ### weekly review
 - summarize totals and conversion rates
 - identify winning segment + message variant
 - decide one copy iteration and one targeting iteration for next cycle
+
+## week-1 baseline targets
+- outreaches_sent: 20
+- positive_replies: >=3
+- discovery_calls_booked: >=1
+- paid pilot path identified: >=1
 
 ## blocker escalation format (>15m)
 Use this exact structure with `needs-human`:

--- a/references/weekly-pilot-scoreboard.csv
+++ b/references/weekly-pilot-scoreboard.csv
@@ -1,2 +1,2 @@
-week_start,week_end,owner,outreaches_sent,replies,positive_replies,discovery_calls_booked,pilots_offered,pilots_closed_paid,revenue_usd,top_blocker,next_iteration_plan
-,,,,,,,,,,,
+week_start,week_end,owner,outreaches_sent,replies,positive_replies,discovery_calls_booked,pilots_offered,pilots_closed_paid,revenue_usd,reply_rate_pct,positive_reply_rate_pct,call_book_rate_pct,pilot_close_rate_pct,discussion_update_url,tracker_snapshot_ref,top_blocker,next_iteration_plan
+,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Closes #8

## Summary
Adds a canonical metrics schema and weekly scoreboard artifact for pilot acquisition tracking:
- `references/pilot-metrics-schema-v1.md`
- `references/weekly-pilot-scoreboard.csv`

## Trigger phrases / intended usage
- "pilot metrics"
- "weekly scoreboard"
- "daily reporting cadence"

## Safety considerations
- Documentation-only PR; no external actions or automation.
- Includes blocker escalation format with `needs-human` for ambiguous/risky stalls.

## Validation steps (how skill was tested)
- Checked artifact coverage against issue #8 scope:
  - canonical metrics fields
  - weekly scoreboard template
  - update cadence + owner model
- Verified schema aligns with existing outreach status conventions.

## Rollback/remove plan
Revert these two files if metric definitions or reporting structure need redesign after first live week.