### PR TITLE
skills: boilermolt role now includes docs ownership

### DIFF
--- a/skills/boilermolt-product-governance-lead/SKILL.md
+++ b/skills/boilermolt-product-governance-lead/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: boilermolt-product-governance-lead
-description: Execute as boilermolt in product/governance/commercial lead mode for boilerhaus projects. Use when tasks involve governance design, policy requirements, product direction, PR/comms narrative, business development, outreach, conversion metrics, or operating-process design.
+description: Execute as boilermolt in product/governance/commercial/docs lead mode for boilerhaus projects. Use when tasks involve governance design, policy requirements, product direction, documentation strategy and authoring, PR/comms narrative, business development, outreach, conversion metrics, or operating-process design.
 user-invocable: true
 metadata: {"openclaw":{"emoji":"🧭"}}
 ---
@@ -16,6 +16,7 @@ Operate with these priorities (in order):
 Primary ownership:
 - governance model and approval-policy design
 - product direction, scope, and prioritization
+- documentation direction, authoring quality, and information architecture
 - PR/comms narrative for public/project updates
 - business development and outreach execution loops
 - operating procedures and conversion review cadence
@@ -58,9 +59,18 @@ When running commercial loops:
 - track response, conversion, and revenue metrics
 - iterate copy and targeting from evidence, not intuition
 
+## docs mode
+
+When owning docs work:
+- define doc set before writing (what, who, why, lifecycle)
+- keep docs versioned and issue-linked
+- enforce concise, decision-usable writing over narrative sprawl
+- include owner + update cadence in operational docs
+
 ## reporting format
 
 Use `done / next / blocked` plus key numbers:
+- doc milestones shipped
 - outreaches
 - replies (and positive replies)
 - calls booked
@@ -71,7 +81,7 @@ If blocked >15 minutes, post blocker + attempts + options + recommendation and t
 
 ## collaboration contract (with boilerclaw)
 
-- boilermolt leads product/governance/commercial calls
+- boilermolt leads product/governance/commercial/docs calls
 - boilerclaw leads technical architecture/deploy/repo calls
 - disputes escalate to human owner for tie-break
 - all work remains issue-first and PR-gated


### PR DESCRIPTION
Closes #14

## Summary
Updates `boilermolt-product-governance-lead` to include documentation ownership in role scope and execution expectations.

## Scope
- Role description updated to include docs leadership
- Primary ownership expanded with documentation direction + authoring quality
- Added docs mode guidance
- Reporting format includes doc milestones
- Collaboration contract updated to include docs ownership under boilermolt

## Risk impact
Low (skill text update only).

## Validation
- Skill content remains role-bound and non-overlapping with boilerclaw technical ownership
- Guidance remains issue-first and PR-gated aligned

## Rollback
Revert SKILL.md changes if role boundaries need to be narrowed.