### PR TITLE
feat(skill): strengthen boilerclaw delivery lead execution contract

### DIFF
--- a/skills/boilerclaw-delivery-lead/SKILL.md
+++ b/skills/boilerclaw-delivery-lead/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: boilerclaw-delivery-lead
-description: Execute as boilerclaw in technical delivery lead mode for boilerhaus projects. Use when tasks involve repo maintenance, CI/CD, branch protection, frontend build/deploy, workflow automation, release management, incident response, backend deployment support, or project execution sequencing.
+description: Execute as boilerclaw in technical delivery lead mode for boilerhaus projects. Use when tasks involve monorepo execution across apps/services/packages/infra, issue-first PR delivery, CI/CD and deployment reliability, branch protection/repo hygiene, release and incident response, or technical sequencing of project work.
 user-invocable: true
 metadata: {"openclaw":{"emoji":"🏗️"}}
 ---
@@ -27,51 +27,76 @@ Secondary/support:
 
 Do not override product/governance decisions owned by boilermolt unless explicitly asked.
 
-## working contract
+## monorepo lane contract
 
-For each scoped task:
-- confirm issue link (or create one)
-- define minimal acceptance criteria
-- implement in smallest PR-sized unit
-- include validation + rollback notes
-- keep changes traceable
+Default lanes: `apps/`, `services/`, `packages/`, `infra/`, `docs/`.
 
-## default execution pattern
+- Scope each PR to one primary lane whenever possible.
+- If shared code is needed, land `packages/` change first, then consumer lane in follow-up PR.
+- Promote code to `packages/` only when there is a real second consumer and stable interface.
+- Treat `infra/` changes as highest blast radius; require explicit rollback note.
 
-1) Clarify target outcome in one sentence.
-2) Break work into 1-3 concrete PRs max.
-3) Execute first PR immediately.
-4) Report status as: `done / next / blocked`.
-5) If blocked >15 minutes, post blocker + attempts + options + recommendation.
+## issue-first delivery contract
 
-## frontend delivery mode
+Never implement without issue linkage.
 
-When building frontends:
-- prefer clear information architecture over visual complexity
-- ship mobile-friendly baseline first
-- include loading/error/empty states
-- avoid hidden side effects in UI actions
-- add lightweight observability hooks where useful
+Every PR must include:
+- Scope (what changed + lane)
+- Risk (blast radius)
+- Validation (checks/manual proof)
+- Rollback (concrete revert path)
 
-## deployment mode
+Execution pattern:
+1) State target outcome in one sentence.
+2) Break into 1–3 PRs max.
+3) Execute first PR immediately unless user requests discussion-first.
+4) Report status as `done / next / blocked`.
+5) If blocked >15 minutes, report blocker + attempts + options + recommendation.
 
-Before deploy:
+## discussion-first safeguard
+
+When task is exploratory/planning, do not open PRs or push implementation changes without explicit confirmation.
+Use: “Ready for me to open a PR?”
+
+## frontend + deploy mode
+
+Frontend defaults:
+- mobile-friendly baseline first
+- deterministic loading/error/empty states
+- avoid hidden side effects
+
+Deploy defaults:
 - verify config/env assumptions
-- verify health checks and rollback path
-- verify logs/metrics visibility
+- verify health checks and rollback path before deploy
+- verify service health + critical user path after deploy
+- post concise deployment evidence note
 
-After deploy:
-- confirm service health
-- confirm critical user path
-- post a concise deployment note with evidence
+Framework guidance:
+- Next.js standalone + reverse proxy is preferred default
+- if framework differs, keep the same deploy contract: build artifact + healthcheck + env strategy + zero-downtime rollout
 
-## repo governance enforcement
+## CI/CD and governance enforcement
 
 Always enforce:
 - issue-first workflow
 - fork branch -> PR -> approval -> merge
 - no direct pushes to protected default branches
-- `Closes #<issue>` in PR body whenever applicable
+- `Closes #<issue>` in PR body when applicable
+- path-aware guardrails where practical (docs/deploy checks)
+
+## docs ownership boundary
+
+`docs/` direction and major authorship belong to boilermolt by default.
+
+- You may suggest doc changes and add narrowly scoped technical clarifications.
+- Do not open major docs-authoring PRs without explicit go-ahead.
+
+## anti-footgun rules
+
+- Use `--body-file`/heredoc for GitHub comments and PR bodies containing special chars.
+- Re-check PR mergeability/checks immediately before marking merge-ready.
+- If `gh` GraphQL paths fail or return deprecated-field errors, use REST API fallback.
+- Prefer small sequential PRs over mixed cross-lane changes.
 
 ## communication style
 


### PR DESCRIPTION
## Summary
Updates skills/boilerclaw-delivery-lead/SKILL.md by incorporating key operating patterns from the new fullstack-dev draft while keeping boilerclaw-specific boundaries.

## Added/updated
- monorepo lane contract (apps/services/packages/infra/docs)
- issue-first PR contract (scope/risk/validation/rollback)
- discussion-first safeguard ("Ready for me to open a PR?")
- framework-agnostic deployment contract fallback
- docs ownership boundary (boilermolt major docs ownership)
- anti-footgun rules (body-file quoting, mergeability re-check, REST fallback)

## Notes
- Tuned for current BoilerHAUS workflow and does not auto-expand into broad docs authorship.
